### PR TITLE
Add requirements file and update README prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,8 @@ services/
 Install dependencies:
 
 ```bash
-pip install -r requirements.txt  # or manually install fastapi sqlalchemy pydantic celery uvicorn
+pip install -r requirements.txt
 ```
-
-> The project ships without a `requirements.txt` file to keep the repository lightweight; install the packages listed above before running the application or tests.
 
 ### Environment variables
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.110.0
+pydantic==2.7.1
+sqlalchemy==2.0.29
+uvicorn[standard]==0.29.0
+httpx==0.27.0
+pytest==8.2.1


### PR DESCRIPTION
## Summary
- add a `requirements.txt` that pins the runtime and pytest dependencies for Python 3.11
- update the README prerequisites to point to the new requirements file without the previous disclaimer

## Testing
- `python3 -m venv .venv`
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccde498688832ebc3a8d9113d166ba